### PR TITLE
mirror effect in camera 

### DIFF
--- a/frontend/components/RTC/DeviceCheck.tsx
+++ b/frontend/components/RTC/DeviceCheck.tsx
@@ -149,7 +149,7 @@ useEffect(() => {
                     autoPlay
                     playsInline
                     muted
-                    className="absolute inset-0 h-full w-full object-cover"
+                    className="absolute inset-0 h-full w-full object-cover transform scale-x-[-1]"
                   />
                 ) : (
                   <div className="absolute inset-0 flex items-center justify-center bg-black">


### PR DESCRIPTION

## Summary
The feed should act like a mirror, just like most selfie cameras do. So if you raise your right hand, it appears on the right side of the screen—matching your actual motion in a way your brain expects.

## Testing Completed
- [ ] ✅ I have tested these changes locally

## Development Setup Verification
- [ ] 📦 Dependencies installed for both frontend and backend
- [ ] 🚀 Development servers start without errors
- [ ] 🏗️ Code builds successfully

## Related Issues
Closes #159 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The self-view in the device check video preview is now mirrored for a more natural, front-facing camera experience.
  * Visual-only adjustment; no changes to controls, error handling, or performance.
  * Improves alignment with common video app expectations, making it easier to adjust framing and orientation before joining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->